### PR TITLE
Updated Doxygen file to show design in main page

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1154,7 +1154,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = design.md
+USE_MDFILE_AS_MAINPAGE =design.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common

--- a/Doxyfile
+++ b/Doxyfile
@@ -1154,7 +1154,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = design.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
updated USE_MDFILE_AS_MAINPAGE field so that design will appear in main page of automated documentation .